### PR TITLE
Fix for potential double-free in Engine::add(System*)

### DIFF
--- a/Overdrive/core/engine.cpp
+++ b/Overdrive/core/engine.cpp
@@ -61,8 +61,10 @@ namespace overdrive {
 				mSystemLookup[s->getName()] = s.get();
 				mSystems.push_back(std::move(s));
 			}
-			else
-				throw std::runtime_error(std::string("Duplicate system added: ") + s->getName());
+			else {
+				auto ptr = s.release();
+				throw std::runtime_error(std::string("Duplicate system added: ") + ptr->getName());
+			}
 		}
 
 		void Engine::remove(const std::string& systemName) {


### PR DESCRIPTION
Hello and first of all thanks for your nice tutorial!

This change fixes a potential double-free bug when trying to add duplicate systems. 

Steps to reproduce:

- Create system instance, pass it to `Engine::add()` twice using the raw pointer overload like in the following example

```
Engine e;
System* sys = new System(); // replace with any valid subclass obviously

e.add(sys); // succeeds as expected
e.add(sys); // throws std::runtime_error but also triggers double-free
````

When doing this we end up with two `unique_ptr` instances pointing to `sys` which will trigger a double free when the exception is thrown in the second call to `Engine::add()`.

This PR calls `unique_ptr::release()` on the erroneously created second smart pointer before throwing the exception.